### PR TITLE
feat: Enable ZERO_COPY

### DIFF
--- a/ucc/src/components/tl/spin/tl_spin.c
+++ b/ucc/src/components/tl/spin/tl_spin.c
@@ -85,6 +85,10 @@ static ucc_config_field_t ucc_tl_spin_context_config_table[] = {
      ucc_offsetof(ucc_tl_spin_context_config_t, max_recv_buf_size),
      UCC_CONFIG_TYPE_UINT},
 
+    {"MCAST_ZERO_COPY_BCAST_ENABLE", "0", "Enable zero-copy multicast bcast (0: disable, 1: enable)",
+     ucc_offsetof(ucc_tl_spin_context_config_t, mcast_zero_copy_bcast_enable),
+     UCC_CONFIG_TYPE_INT},
+
     {NULL}};
 
 UCC_CLASS_DEFINE_NEW_FUNC(ucc_tl_spin_context_t, ucc_base_context_t,

--- a/ucc/src/components/tl/spin/tl_spin.h
+++ b/ucc/src/components/tl/spin/tl_spin.h
@@ -52,6 +52,7 @@ typedef struct ucc_tl_spin_context_config {
     int                     timeout_scaling_param;
     int                     n_ag_mcast_roots;
     unsigned int            max_recv_buf_size;
+    int                     mcast_zero_copy_bcast_enable;
 } ucc_tl_spin_context_config_t;
 
 typedef struct ucc_tl_spin_lib {
@@ -252,6 +253,7 @@ typedef struct ucc_tl_spin_task {
     atomic_int                   tx_start;
     atomic_int                   tx_compls;
     atomic_int                   rx_compls;
+    atomic_int                   rx_ready_compls;
     ucc_tl_spin_task_type_t      coll_type;
     uint32_t                     id;
     size_t                       src_buf_size;

--- a/ucc/src/components/tl/spin/tl_spin_allgather.c
+++ b/ucc/src/components/tl/spin/tl_spin_allgather.c
@@ -53,16 +53,6 @@ static ucc_status_t ucc_tl_spin_allgather_start(ucc_coll_task_t *coll_task)
     if (status != UCC_OK) {
         return status;
     }
-    if (!UCC_IS_INPLACE(task->super.bargs.args)) {
-        status = ucc_mc_memcpy(PTR_OFFSET(task->dst_ptr, task->src_buf_size * UCC_TL_TEAM_RANK(team)),
-                               task->src_ptr,
-                               task->src_buf_size,
-                               task->super.bargs.args.dst.info.mem_type, 
-                               task->super.bargs.args.dst.info.mem_type);
-        if (ucc_unlikely(UCC_OK != status)) {
-            return status;
-        }
-    }
     coll_task->status = UCC_INPROGRESS;
     tl_debug(UCC_TASK_LIB(task), "start coll task ptr=%p tgid=%u", task, task->id);
     return ucc_progress_queue_enqueue(UCC_TL_CORE_CTX(team)->pq, &task->super);

--- a/ucc/src/components/tl/spin/tl_spin_allgather.c
+++ b/ucc/src/components/tl/spin/tl_spin_allgather.c
@@ -111,10 +111,14 @@ ucc_status_t ucc_tl_spin_allgather_init(ucc_tl_spin_task_t   *task,
     if (task->last_pkt_size) {
         task->pkts_to_send++;
     }
-    task->pkts_to_recv     = task->pkts_to_send * (UCC_TL_TEAM_SIZE(team) - 1);
     task->start_chunk_id   = task->pkts_to_send * UCC_TL_TEAM_RANK(team);
     task->inplace_start_id = task->start_chunk_id;
     task->inplace_end_id   = task->inplace_start_id + task->pkts_to_send - 1;
+    if (ctx->cfg.mcast_zero_copy_bcast_enable) {
+        task->pkts_to_recv = task->pkts_to_send * UCC_TL_TEAM_SIZE(team);
+    } else {
+        task->pkts_to_recv = task->pkts_to_send * (UCC_TL_TEAM_SIZE(team) - 1);
+    }
 
     task->ag.mcast_seq_starter  = UCC_TL_TEAM_RANK(team)       % seq_length == 0 ? 1 : 0;
     task->ag.mcast_seq_finisher = (UCC_TL_TEAM_RANK(team) + 1) % seq_length == 0 ? 1 : 0;
@@ -186,6 +190,7 @@ ucc_tl_spin_coll_worker_rx_allgather_start(ucc_tl_spin_worker_info_t *ctx, ucc_t
     ucc_status_t status;
 
     if (ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
+        ucc_assert_always(ctx->ctx->cfg.n_mcg == 1);
         ucc_assert_always(ctx->ctx->cfg.n_tx_workers == 1 && ctx->ctx->cfg.n_rx_workers == 1);
         ucc_assert_always(cur_task->pkts_to_send * UCC_TL_TEAM_SIZE(ctx->team) <= ctx->ctx->cfg.mcast_rq_depth);
 

--- a/ucc/src/components/tl/spin/tl_spin_allgather.c
+++ b/ucc/src/components/tl/spin/tl_spin_allgather.c
@@ -39,7 +39,11 @@ static ucc_status_t ucc_tl_spin_allgather_start(ucc_coll_task_t *coll_task)
 
     errno = 0;
     reg_changed = 0;
-    if (UCC_OK != ucc_rcache_get(ctx->p2p.rcache,
+    ucc_rcache_t *rcache = ctx->p2p.rcache;
+    if (ctx->cfg.mcast_zero_copy_bcast_enable) {
+        rcache = ctx->mcast.rcache;
+    }
+    if (UCC_OK != ucc_rcache_get(rcache,
                                  task->dst_ptr,
                                  task->dst_buf_size,
                                  &reg_changed,
@@ -134,6 +138,10 @@ ucc_status_t ucc_tl_spin_allgather_init(ucc_tl_spin_task_t   *task,
              task->src_ptr, task->src_buf_size, task->dst_ptr, task->dst_buf_size,
              task->pkts_to_send, task->pkts_to_recv);
 
+    if (ctx->cfg.mcast_zero_copy_bcast_enable) {
+        atomic_store(&task->rx_ready_compls,0);
+    }
+
     return UCC_OK;
 }
 
@@ -144,6 +152,13 @@ ucc_tl_spin_coll_worker_tx_allgather_start(ucc_tl_spin_worker_info_t *ctx, ucc_t
     int                 compls;
     struct ibv_wc       wc[1];
 
+    if (ctx->ctx->cfg.mcast_zero_copy_bcast_enable && cur_task->ag.mcast_seq_starter) {
+        while (atomic_load(&cur_task->rx_ready_compls) < ctx->ctx->cfg.n_rx_workers) {
+            // busy wait
+        }
+        tl_debug(UCC_TL_SPIN_TEAM_LIB(ctx->team), "tx handler %d received all rx handlers ready signal", UCC_TL_TEAM_RANK(ctx->team));
+    }
+ 
     if (!cur_task->ag.mcast_seq_starter) {
         compls = ib_cq_poll(ctx->reliability.cq, 1, wc);
         ucc_assert_always(compls == 1 && (wc->opcode == IBV_WC_RECV));
@@ -170,11 +185,40 @@ ucc_tl_spin_coll_worker_rx_allgather_start(ucc_tl_spin_worker_info_t *ctx, ucc_t
 {
     ucc_status_t status;
 
+    if (ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
+        ucc_assert_always(ctx->ctx->cfg.n_tx_workers == 1 && ctx->ctx->cfg.n_rx_workers == 1);
+        ucc_assert_always(cur_task->pkts_to_send * UCC_TL_TEAM_SIZE(ctx->team) <= ctx->ctx->cfg.mcast_rq_depth);
+
+        int qp_id = 0;
+        status = ucc_tl_spin_prepare_mcg_rwrs_zero_copy(ctx->rwrs[0], ctx->rsges[0],
+                                                        ctx->grh_buf[0], ctx->grh_buf_mr[0],
+                                                        cur_task->dst_ptr, cur_task->cached_rbuf_mkey->mr,
+                                                        ctx->ctx->mcast.mtu, UCC_TL_TEAM_SIZE(ctx->team),
+                                                        cur_task->pkts_to_send, cur_task->src_buf_size, qp_id);
+        ucc_assert_always(status == UCC_OK);
+        status = ucc_tl_spin_team_prepost_mcast_qp_zero_copy(ctx->ctx, ctx,
+                                                             UCC_TL_TEAM_SIZE(ctx->team),
+                                                             cur_task->pkts_to_send,
+                                                             qp_id);
+        ucc_assert_always(status == UCC_OK);
+
+        // wait for all rx workers post recv wrs
+        ucc_tl_spin_team_t *team = UCC_TL_SPIN_TASK_TEAM(cur_task);
+        ucc_tl_spin_team_rc_ring_barrier(UCC_TL_TEAM_RANK(team), team->ctrl_ctx);
+
+        // if this process is starter, signal tx workers to start
+        if (cur_task->ag.mcast_seq_starter) {
+            atomic_fetch_add(&cur_task->rx_ready_compls, 1);
+        }
+    }
+ 
     status = ucc_tl_spin_coll_worker_rx_handler(ctx, cur_task);
     ucc_assert_always(status == UCC_OK);
 
-    status  = ucc_tl_spin_coll_worker_rx_reliability_handler(ctx, cur_task);
-    ucc_assert_always(status == UCC_OK);
+    if (!ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
+        status  = ucc_tl_spin_coll_worker_rx_reliability_handler(ctx, cur_task);
+        ucc_assert_always(status == UCC_OK);
+    }
 
     return UCC_OK;
 }

--- a/ucc/src/components/tl/spin/tl_spin_bcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_bcast.c
@@ -532,14 +532,14 @@ inline ucc_status_t
 ucc_tl_spin_coll_worker_rx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_task_t *cur_task)
 {
 #ifndef UCC_TL_SPIN_DISABLE_MCAST
-    // void                         *rbuf                = ctx->staging_rbuf[0];
+    void                         *rbuf                = ctx->staging_rbuf[0];
     size_t                       *tail_idx            = &ctx->tail_idx[0];
     void                         *buf                 = cur_task->dst_ptr + ctx->id * cur_task->tx_thread_work;
     size_t                        mtu                 = ctx->ctx->mcast.mtu;
     double                        timeout             = cur_task->timeout;
     uint32_t                      chunk_id            = 0;
     size_t                        rank_id             = 0;
-    // size_t                        rank_buf_offset;
+    size_t                        rank_buf_offset;
     ucc_tl_spin_packed_chunk_id_t packed_chunk_id;
     double                        t_start, t_end;
     size_t                        pkt_len;
@@ -580,29 +580,32 @@ ucc_tl_spin_coll_worker_rx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_t
                 goto repost_rwr;
             }
 
-            // ready to copy
-            rank_id = chunk_id / cur_task->pkts_to_send;
-            ucc_assert_always(rank_id < UCC_TL_TEAM_SIZE(ctx->team));
-            if (cur_task->coll_type == UCC_TL_SPIN_WORKER_TASK_TYPE_BCAST) {
-                ucc_assert_always(rank_id == 0);
+            if (!ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
+                // ready to copy
+                rank_id = chunk_id / cur_task->pkts_to_send;
+                ucc_assert_always(rank_id < UCC_TL_TEAM_SIZE(ctx->team));
+                if (cur_task->coll_type == UCC_TL_SPIN_WORKER_TASK_TYPE_BCAST) {
+                    ucc_assert_always(rank_id == 0);
+                }
+                rank_buf_offset = chunk_id % cur_task->pkts_to_send;
+                ucc_status_t status;
+                status = ucc_mc_memcpy(PTR_OFFSET(buf, cur_task->src_buf_size * rank_id + mtu * rank_buf_offset),
+                                       PTR_OFFSET(rbuf, mtu * (*tail_idx)),
+                                       pkt_len,
+                                       cur_task->src_mem_type,
+                                       cur_task->dst_mem_type);
+                ucc_assert_always(status == UCC_OK);
+                ucc_tl_spin_bitmap_set_bit(&ctx->reliability.bitmap, chunk_id);
+                ctx->reliability.recvd_per_rank[rank_id]++;
+                ctx->reliability.to_recv--;
             }
-            // rank_buf_offset = chunk_id % cur_task->pkts_to_send;
-            // ucc_status_t status;
-            // status = ucc_mc_memcpy(PTR_OFFSET(buf, cur_task->src_buf_size * rank_id + mtu * rank_buf_offset),
-            //                        PTR_OFFSET(rbuf, mtu * (*tail_idx)),
-            //                        pkt_len,
-            //                        cur_task->src_mem_type,
-            //                        cur_task->dst_mem_type);
-            // ucc_assert_always(status == UCC_OK);
-            ucc_tl_spin_bitmap_set_bit(&ctx->reliability.bitmap, chunk_id);
-            ctx->reliability.recvd_per_rank[rank_id]++;
-            ctx->reliability.to_recv--;
 
 repost_rwr:
-            ib_qp_post_recv_wr(ctx->qps[0], &ctx->rwrs[0][*tail_idx]);
-            *tail_idx = (*tail_idx + 1) % ctx->ctx->cfg.mcast_rq_depth;
-            ucc_assert_always(mtu * (*tail_idx) <= ctx->staging_rbuf_len);
-            
+            if (!ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
+                ib_qp_post_recv_wr(ctx->qps[0], &ctx->rwrs[0][*tail_idx]);
+                *tail_idx = (*tail_idx + 1) % ctx->ctx->cfg.mcast_rq_depth;
+                ucc_assert_always(mtu * (*tail_idx) <= ctx->staging_rbuf_len);
+            }
             tl_debug(UCC_TL_SPIN_TEAM_LIB(ctx->team),
                      "rx worker %u stored chunk of size: %zu, id: %u",
                      ctx->id, pkt_len, chunk_id);

--- a/ucc/src/components/tl/spin/tl_spin_bcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_bcast.c
@@ -532,14 +532,14 @@ inline ucc_status_t
 ucc_tl_spin_coll_worker_rx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_task_t *cur_task)
 {
 #ifndef UCC_TL_SPIN_DISABLE_MCAST
-    void                         *rbuf                = ctx->staging_rbuf[0];
+    // void                         *rbuf                = ctx->staging_rbuf[0];
     size_t                       *tail_idx            = &ctx->tail_idx[0];
     void                         *buf                 = cur_task->dst_ptr + ctx->id * cur_task->tx_thread_work;
     size_t                        mtu                 = ctx->ctx->mcast.mtu;
     double                        timeout             = cur_task->timeout;
     uint32_t                      chunk_id            = 0;
     size_t                        rank_id             = 0;
-    size_t                        rank_buf_offset;
+    // size_t                        rank_buf_offset;
     ucc_tl_spin_packed_chunk_id_t packed_chunk_id;
     double                        t_start, t_end;
     size_t                        pkt_len;
@@ -586,14 +586,14 @@ ucc_tl_spin_coll_worker_rx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_t
             if (cur_task->coll_type == UCC_TL_SPIN_WORKER_TASK_TYPE_BCAST) {
                 ucc_assert_always(rank_id == 0);
             }
-            rank_buf_offset = chunk_id % cur_task->pkts_to_send;
-            ucc_status_t status;
-            status = ucc_mc_memcpy(PTR_OFFSET(buf, cur_task->src_buf_size * rank_id + mtu * rank_buf_offset),
-                                   PTR_OFFSET(rbuf, mtu * (*tail_idx)),
-                                   pkt_len,
-                                   cur_task->src_mem_type,
-                                   cur_task->dst_mem_type);
-            ucc_assert_always(status == UCC_OK);
+            // rank_buf_offset = chunk_id % cur_task->pkts_to_send;
+            // ucc_status_t status;
+            // status = ucc_mc_memcpy(PTR_OFFSET(buf, cur_task->src_buf_size * rank_id + mtu * rank_buf_offset),
+            //                        PTR_OFFSET(rbuf, mtu * (*tail_idx)),
+            //                        pkt_len,
+            //                        cur_task->src_mem_type,
+            //                        cur_task->dst_mem_type);
+            // ucc_assert_always(status == UCC_OK);
             ucc_tl_spin_bitmap_set_bit(&ctx->reliability.bitmap, chunk_id);
             ctx->reliability.recvd_per_rank[rank_id]++;
             ctx->reliability.to_recv--;

--- a/ucc/src/components/tl/spin/tl_spin_bcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_bcast.c
@@ -30,7 +30,11 @@ static ucc_status_t ucc_tl_spin_bcast_start(ucc_coll_task_t *coll_task)
 
     errno = 0;
     reg_changed = 0;
-    if (UCC_OK != ucc_rcache_get(ctx->p2p.rcache,
+    ucc_rcache_t *rcache = ctx->p2p.rcache;
+    if (ctx->cfg.mcast_zero_copy_bcast_enable) {
+        rcache = ctx->mcast.rcache;
+    }
+    if (UCC_OK != ucc_rcache_get(rcache,
                                  task->dst_ptr,
                                  task->dst_buf_size,
                                  &reg_changed,
@@ -126,6 +130,10 @@ ucc_status_t ucc_tl_spin_bcast_init(ucc_tl_spin_task_t   *task,
     tl_debug(UCC_TL_SPIN_TEAM_LIB(team), "got new task of size: %zu src_ptr: %p", 
              count * dt_size, task->src_ptr);
 
+    if (ctx->cfg.mcast_zero_copy_bcast_enable) {
+        atomic_store(&task->rx_ready_compls,0);
+    }
+
     return UCC_OK;
 }
 
@@ -133,6 +141,12 @@ inline ucc_status_t
 ucc_tl_spin_coll_worker_tx_bcast_start(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_task_t *cur_task)
 {
     if (ctx->team->subset.myrank == cur_task->super.bargs.args.root) {
+        if (ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
+            while (atomic_load(&cur_task->rx_ready_compls) < ctx->ctx->cfg.n_rx_workers) {
+                // busy wait
+            }
+            tl_debug(UCC_TL_SPIN_TEAM_LIB(ctx->team), "tx handler %d received all rx handlers ready signal", UCC_TL_TEAM_RANK(ctx->team));
+        }
         return ucc_tl_spin_coll_worker_tx_handler(ctx, cur_task);
     }
     return UCC_OK;
@@ -142,6 +156,38 @@ inline ucc_status_t
 ucc_tl_spin_coll_worker_rx_bcast_start(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_task_t *cur_task)
 {
     ucc_status_t status;
+
+    if (ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
+        ucc_assert_always(ctx->ctx->cfg.n_mcg == 1);
+        ucc_assert_always(ctx->ctx->cfg.n_tx_workers == 1 && ctx->ctx->cfg.n_rx_workers == 1);
+        ucc_assert_always(cur_task->pkts_to_send * UCC_TL_TEAM_SIZE(ctx->team) <= ctx->ctx->cfg.mcast_rq_depth);
+
+        if (ctx->team->subset.myrank != cur_task->super.bargs.args.root) {
+            int qp_id = 0;
+            size_t send_team_size = 1;  // number of ranks to send is only one, root
+            status = ucc_tl_spin_prepare_mcg_rwrs_zero_copy(ctx->rwrs[0], ctx->rsges[0],
+                                                            ctx->grh_buf[0], ctx->grh_buf_mr[0],
+                                                            cur_task->dst_ptr, cur_task->cached_rbuf_mkey->mr,
+                                                            ctx->ctx->mcast.mtu, send_team_size,
+                                                            cur_task->pkts_to_send, cur_task->src_buf_size, qp_id);
+            ucc_assert_always(status == UCC_OK);
+            status = ucc_tl_spin_team_prepost_mcast_qp_zero_copy(ctx->ctx, ctx,
+                                                                 send_team_size,
+                                                                 cur_task->pkts_to_send,
+                                                                 qp_id);
+            ucc_assert_always(status == UCC_OK);
+        }
+
+        // wait for all rx workers post recv wrs
+        ucc_tl_spin_team_t *team = UCC_TL_SPIN_TASK_TEAM(cur_task);
+        ucc_tl_spin_team_rc_ring_barrier(UCC_TL_TEAM_RANK(team), team->ctrl_ctx);
+
+        // if this process is root, signal tx workers to start
+        if (ctx->team->subset.myrank == cur_task->super.bargs.args.root) {
+            atomic_fetch_add(&cur_task->rx_ready_compls, 1);
+        }
+    }
+
     if (ctx->team->subset.myrank != cur_task->super.bargs.args.root) {
         status = ucc_tl_spin_coll_worker_rx_handler(ctx, cur_task);
         ucc_assert_always(status == UCC_OK);

--- a/ucc/src/components/tl/spin/tl_spin_bcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_bcast.c
@@ -549,6 +549,7 @@ ucc_tl_spin_coll_worker_rx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_t
             "rx worker %u got bcast task of size: %zu n_batches: %zu last_batch_size: %zu last_pkt_sz: %zu buf: %p, tgid=%u", 
              ctx->id, cur_task->tx_thread_work, cur_task->n_batches, cur_task->last_batch_size, 
              cur_task->last_pkt_size, buf, cur_task->id);
+    tl_debug(UCC_TL_SPIN_TEAM_LIB(ctx->team), "rx worker %u zero copy bcast: %d", ctx->id, ctx->ctx->cfg.mcast_zero_copy_bcast_enable);
 #endif
     ctx->reliability.to_recv = cur_task->pkts_to_recv;
 #ifndef UCC_TL_SPIN_DISABLE_MCAST
@@ -575,12 +576,13 @@ ucc_tl_spin_coll_worker_rx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_t
                      ctx->id, pkt_len, chunk_id, *tail_idx);
 
             // ignore loopback traffic in cast of allgather
-            if ((cur_task->inplace_start_id <= chunk_id) && (chunk_id <= cur_task->inplace_end_id)) {
-                    tl_debug(UCC_TL_SPIN_TEAM_LIB(ctx->team), "got loopback chunk id");
-                goto repost_rwr;
-            }
-
             if (!ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
+                // ignore loopback traffic in cast of allgather
+                if ((cur_task->inplace_start_id <= chunk_id) && (chunk_id <= cur_task->inplace_end_id)) {
+                        tl_debug(UCC_TL_SPIN_TEAM_LIB(ctx->team), "got loopback chunk id");
+                    goto repost_rwr;
+                }
+
                 // ready to copy
                 rank_id = chunk_id / cur_task->pkts_to_send;
                 ucc_assert_always(rank_id < UCC_TL_TEAM_SIZE(ctx->team));
@@ -595,20 +597,21 @@ ucc_tl_spin_coll_worker_rx_handler(ucc_tl_spin_worker_info_t *ctx, ucc_tl_spin_t
                                        cur_task->src_mem_type,
                                        cur_task->dst_mem_type);
                 ucc_assert_always(status == UCC_OK);
-                ucc_tl_spin_bitmap_set_bit(&ctx->reliability.bitmap, chunk_id);
-                ctx->reliability.recvd_per_rank[rank_id]++;
-                ctx->reliability.to_recv--;
             }
+
+            ucc_tl_spin_bitmap_set_bit(&ctx->reliability.bitmap, chunk_id);
+            ctx->reliability.recvd_per_rank[rank_id]++;
+            ctx->reliability.to_recv--;
 
 repost_rwr:
             if (!ctx->ctx->cfg.mcast_zero_copy_bcast_enable) {
                 ib_qp_post_recv_wr(ctx->qps[0], &ctx->rwrs[0][*tail_idx]);
                 *tail_idx = (*tail_idx + 1) % ctx->ctx->cfg.mcast_rq_depth;
                 ucc_assert_always(mtu * (*tail_idx) <= ctx->staging_rbuf_len);
+                tl_debug(UCC_TL_SPIN_TEAM_LIB(ctx->team),
+                         "rx worker %u stored chunk of size: %zu, id: %u",
+                         ctx->id, pkt_len, chunk_id);
             }
-            tl_debug(UCC_TL_SPIN_TEAM_LIB(ctx->team),
-                     "rx worker %u stored chunk of size: %zu, id: %u",
-                     ctx->id, pkt_len, chunk_id);
         }
         t_end = ucc_get_time();
         ucc_assert_always(t_start <= t_end);

--- a/ucc/src/components/tl/spin/tl_spin_mcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_mcast.c
@@ -266,6 +266,25 @@ ucc_tl_spin_team_prepost_mcast_qp(ucc_tl_spin_context_t *ctx,
     return UCC_OK;
 }
 
+ucc_status_t 
+ucc_tl_spin_team_prepost_mcast_qp_zero_copy(ucc_tl_spin_context_t *ctx,
+                                            ucc_tl_spin_worker_info_t *worker,
+                                            size_t team_size,
+                                            size_t pkts_to_send,
+                                            int qp_id)
+{
+    struct ibv_qp *qp       = worker->qps[qp_id];
+    int            i;
+
+    for (int src_rank = 0; src_rank < team_size; src_rank++) {
+        for (i = 0; i < pkts_to_send; i++) {
+            ib_qp_post_recv_wr(qp, &worker->rwrs[qp_id][i]);
+        }
+    }
+
+    return UCC_OK;
+}
+
 ucc_status_t
 ucc_tl_spin_prepare_mcg_rwrs(struct ibv_recv_wr *wrs, struct ibv_sge *sges,
                              char *grh_buf, struct ibv_mr *grh_buf_mr,
@@ -295,6 +314,49 @@ ucc_tl_spin_prepare_mcg_rwrs(struct ibv_recv_wr *wrs, struct ibv_sge *sges,
         wrs[i].wr_id   = wr_id;
     }
 
+    return UCC_OK;
+}
+
+ucc_status_t
+ucc_tl_spin_prepare_mcg_rwrs_zero_copy(struct ibv_recv_wr *wrs, struct ibv_sge *sges,
+                                       char *grh_buf, struct ibv_mr *grh_buf_mr,
+                                       char *buf, struct ibv_mr *buf_mr,
+                                       size_t mtu, size_t team_size, size_t pkts_to_send,
+                                       size_t src_buf_size, uint64_t wr_id)
+{
+    int i = 0, j = 0, k = 0;
+    size_t len;
+    size_t remaining_len;
+    
+    for (int src_rank = 0; src_rank < team_size; src_rank++) {
+        remaining_len = src_buf_size;
+        for (k = 0, j = 0; k < pkts_to_send; k++, i++, j += 2) {
+            if (k == pkts_to_send - 1) {
+                assert(remaining_len <= mtu);
+                len = remaining_len;
+            } else {
+                len = mtu;
+            }
+
+            // GRH
+            sges[j].addr   = (uint64_t)grh_buf;
+            sges[j].lkey   = grh_buf_mr->lkey;
+            sges[j].length = 40;
+            grh_buf += UCC_TL_SPIN_IB_GRH_FOOTPRINT;
+
+            // Payload
+            sges[j + 1].addr   = (uint64_t)PTR_OFFSET(buf, src_buf_size * src_rank + mtu * k);
+            sges[j + 1].lkey   = buf_mr->lkey;
+            sges[j + 1].length = len;
+            remaining_len -= len;
+    
+            // WR
+            memset(&wrs[i], 0, sizeof(struct ibv_recv_wr));
+            wrs[i].sg_list = &sges[j];
+            wrs[i].num_sge = 2;
+            wrs[i].wr_id   = wr_id;
+        }
+    }
     return UCC_OK;
 }
 

--- a/ucc/src/components/tl/spin/tl_spin_mcast.c
+++ b/ucc/src/components/tl/spin/tl_spin_mcast.c
@@ -273,12 +273,13 @@ ucc_tl_spin_team_prepost_mcast_qp_zero_copy(ucc_tl_spin_context_t *ctx,
                                             size_t pkts_to_send,
                                             int qp_id)
 {
-    struct ibv_qp *qp       = worker->qps[qp_id];
-    int            i;
+    struct ibv_qp *qp = worker->qps[qp_id];
+    int            i  = 0, j;
 
     for (int src_rank = 0; src_rank < team_size; src_rank++) {
-        for (i = 0; i < pkts_to_send; i++) {
+        for (j = 0; j < pkts_to_send; j++, i++) {
             ib_qp_post_recv_wr(qp, &worker->rwrs[qp_id][i]);
+            tl_warn(UCC_TL_SPIN_CTX_LIB(ctx), "post recv wr %d, payload buf=%p", i, (void*)(worker->rwrs[qp_id][i].sg_list[1].addr));
         }
     }
 
@@ -330,7 +331,7 @@ ucc_tl_spin_prepare_mcg_rwrs_zero_copy(struct ibv_recv_wr *wrs, struct ibv_sge *
     
     for (int src_rank = 0; src_rank < team_size; src_rank++) {
         remaining_len = src_buf_size;
-        for (k = 0, j = 0; k < pkts_to_send; k++, i++, j += 2) {
+        for (k = 0; k < pkts_to_send; k++, i++, j += 2) {
             if (k == pkts_to_send - 1) {
                 assert(remaining_len <= mtu);
                 len = remaining_len;

--- a/ucc/src/components/tl/spin/tl_spin_mcast.h
+++ b/ucc/src/components/tl/spin/tl_spin_mcast.h
@@ -26,9 +26,28 @@ ucc_tl_spin_prepare_mcg_rwrs(struct ibv_recv_wr *wrs, struct ibv_sge *sges,
                              char *staging_rbuf, struct ibv_mr *staging_rbuf_mr,
                              size_t mtu, size_t qp_depth, uint64_t wr_id);
 ucc_status_t
+ucc_tl_spin_prepare_mcg_rwrs_zero_copy(struct ibv_recv_wr *wrs, struct ibv_sge *sges,
+                                       char *grh_buf, struct ibv_mr *grh_buf_mr,
+                                       char *buf, struct ibv_mr *buf_mr,
+                                       size_t mtu, size_t team_size, size_t pkts_to_send,
+                                       size_t src_buf_size, uint64_t wr_id);
+ucc_status_t
 ucc_tl_spin_team_prepost_mcast_qp(ucc_tl_spin_context_t *ctx,
                                   ucc_tl_spin_worker_info_t *worker,
                                   int qp_id);
+ucc_status_t
+ucc_tl_spin_team_prepost_mcast_qp_zero_copy(ucc_tl_spin_context_t *ctx,
+                                            ucc_tl_spin_worker_info_t *worker,
+                                            size_t team_size,
+                                            size_t pkts_to_send,
+                                            int qp_id);
+ucc_status_t
+ucc_tl_spin_team_prepost_mcast_qp_zero_copy(ucc_tl_spin_context_t *ctx,
+                                            ucc_tl_spin_worker_info_t *worker,
+                                            size_t team_size,
+                                            size_t pkts_to_send,
+                                            int qp_id);
+
 void
 ib_qp_ud_post_mcast_send(struct ibv_qp *qp, struct ibv_ah *ah, struct ibv_send_wr *wr,
                          struct ibv_mr *mr, void *buf, uint32_t len, 

--- a/ucc/src/components/tl/spin/tl_spin_team.c
+++ b/ucc/src/components/tl/spin/tl_spin_team.c
@@ -253,11 +253,13 @@ UCC_CLASS_INIT_FUNC(ucc_tl_spin_team_t, ucc_base_context_t *tl_context,
                     tl_error(tl_context->lib, "allocation of ssges buffer failed");
                     return UCC_ERR_NO_MEMORY;
                 }
-                status = ucc_tl_spin_prepare_mcg_rwrs(worker->rwrs[j], worker->rsges[j],
-                                                      worker->grh_buf[j], worker->grh_buf_mr[j],
-                                                      worker->staging_rbuf[j], worker->staging_rbuf_mr[j],
-                                                      ctx->mcast.mtu, ctx->cfg.mcast_rq_depth, j);
-                ucc_assert_always(status == UCC_OK);
+                if (ctx->cfg.mcast_zero_copy_bcast_enable) {
+                    status = ucc_tl_spin_prepare_mcg_rwrs(worker->rwrs[j], worker->rsges[j],
+                                                          worker->grh_buf[j], worker->grh_buf_mr[j],
+                                                          worker->staging_rbuf[j], worker->staging_rbuf_mr[j],
+                                                          ctx->mcast.mtu, ctx->cfg.mcast_rq_depth, j);
+                    ucc_assert_always(status == UCC_OK);
+                }
                 worker->tail_idx[j] = 0;
             }
 

--- a/ucc/src/components/tl/spin/tl_spin_team.c
+++ b/ucc/src/components/tl/spin/tl_spin_team.c
@@ -600,8 +600,10 @@ static ucc_status_t ucc_tl_spin_team_init_mcast_qps(ucc_base_team_t *tl_team)
                 ucc_assert(worker->type == UCC_TL_SPIN_WORKER_TYPE_RX);
                 status = ucc_tl_spin_team_setup_mcast_qp(ctx, worker, &team->mcg_infos[mcg_id], 0, j);
                 ucc_assert(status == UCC_OK);
-                status = ucc_tl_spin_team_prepost_mcast_qp(ctx, worker, j);
-                ucc_assert(status == UCC_OK);
+                if (!ctx->cfg.mcast_zero_copy_bcast_enable) {
+                    status = ucc_tl_spin_team_prepost_mcast_qp(ctx, worker, j);
+                    ucc_assert(status == UCC_OK);
+                }
             }
             tl_debug(lib, "worker %d qp %d %p attached to cq %p", i, j, worker->qps[j], worker->cq);
             mcg_id = (mcg_id + 1) % ctx->cfg.n_mcg;


### PR DESCRIPTION
### Add Zero-Copy Mechanism for Allgather and Bcast (Broadcast)

This PR introduces a zero-copy strategy for CUDA memory in the Allgather and Broadcast operation, controlled via a new parameter:
- MCAST_ZERO_COPY_BCAST_ENABLE (default: 0)

### Behavior:
- When MCAST_ZERO_COPY_BCAST_ENABLE=0 (default):
    - The original behavior is retained. The multicast receive address points to a staging buffer allocated within ucc/spin. After multicast receiving, data is copied from this buffer to the user-provided destination pointer (dst_ptr).
- When MCAST_ZERO_COPY_BCAST_ENABLE=1:
    -  The user’s destination pointer (dst_ptr) is directly used as the multicast receive address, eliminating the intermediate copy from the staging buffer and enabling true zero-copy transfer.

This enhancement improves performance in CUDA-enabled environments by reducing memory movement overhead during Allgather.
